### PR TITLE
Remove arch. extentions on packages

### DIFF
--- a/hammerdb/install-script
+++ b/hammerdb/install-script
@@ -83,10 +83,10 @@ install_mariadb()
 	#
 	# Install Mariadb Server and tools
 	#
-#	dnf -y install mariadb.x86_64 mariadb-common.x86_64 mariadb-devel.x86_64 \
-#	mariadb-errmsg.x86_64 mariadb-server.x86_64 mariadb-server-utils.x86_64 mysql-libs.x86_64
-	dnf -y install mariadb.x86_64 mariadb-common.x86_64 \
-	mariadb-errmsg.x86_64 mariadb-server.x86_64 mariadb-server-utils.x86_64
+#	dnf -y install mariadb mariadb-common mariadb-devel \
+#	mariadb-errmsg mariadb-server mariadb-server-utils mysql-libs
+	dnf -y install mariadb mariadb-common \
+	mariadb-errmsg mariadb-server mariadb-server-utils
 
 
 	#
@@ -146,7 +146,7 @@ install_postgres()
 	#
 	# Installing Postgres Server and tools
 	#
-	dnf -y install postgresql.x86_64 postgresql-contrib.x86_64 postgresql-server.x86_64 glibc-langpack-en libpq
+	dnf -y install postgresql postgresql-contrib postgresql-server glibc-langpack-en libpq
 
 	cd /usr/local/HammerDB
 	cp -R /tmp/hammerdb-tpcc/postgres/* .


### PR DESCRIPTION
# Description
Hammerdb is installing packages that have embedded the architecture name.  In RHEL 10, the install of these packages are failing as the arch name is no longer part of the package name.
As dnf by default will handle the extensions (if they exist), we simply need to remove the architecture name from the various packages.

# Before/After Comparison
Before: dnf will fail.
After: dnf passes.

# Clerical Stuff
This closes #36 
to close the issue out automatically.

Relates to JIRA: RPOPC-494
# Testing
Verified hammer runs properly with the package extensions removed.
