### PR TITLE
Need to designate the uploads area to install-script

### DIFF
--- a/hammerdb/run_hammerdb
+++ b/hammerdb/run_hammerdb
@@ -110,9 +110,9 @@ install_it()
 		# Local system
 		#
 		if [[ $mountpoint == *"none"* ]]; then
-			./install-script -d ${disklist} -t $1 ${log_mount_point}
+			./install-script -d ${disklist} -t $1 ${log_mount_point} -u /${to_home_root}/${to_user}/uploads
 		else
-			./install-script -m ${mountpoint} -t $1 ${log_mount_point}
+			./install-script -m ${mountpoint} -t $1 ${log_mount_point} -u /${to_home_root}/${to_user}/uploads
 		fi
 		if [[ $2 != "none" ]]; then
 			systemctl restart ${2} 


### PR DESCRIPTION
# Description
Fixes hammerdb failing when uploads is not in /

# Before/After Comparison
Before:  hammerdb fails when uploads is not in /
After: Hammerdb runs successfully when uploads is not in /

# Clerical Stuff
This closes #49 

Relates to JIRA: RPOPC-856

Testing command
/home/ec2-user/workloads/hammerdb-wrapper-2.3/hammerdb/hammerdb --run_user ec2-user --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config "m7i.2xlarge" --sysname "m7i.2xlarge" --sys_type aws    --use_pcp --disks grab_disks --sub_test mariadb

csv output
connection,TPM,Start_Date,End_Date
10,393617,2026-03-04T14:11:19Z,2026-03-04T14:28:26Z
20,431437,2026-03-04T14:28:37Z,2026-03-04T14:45:44Z
40,444699,2026-03-04T14:45:54Z,2026-03-04T15:03:02Z

