### PR TITLE
Fix test_tools load not to call exit_out

### DIFF
--- a/hammerdb/hammerdb
+++ b/hammerdb/hammerdb
@@ -66,22 +66,11 @@ warehouses=""
 TOOLS_BIN="${HOME}/test_tools"
 export TOOLS_BIN
 
-attempt_tools_wget()
+attempt_tools_generic()
 {
+	method="$1"
         if [[ ! -d "$TOOLS_BIN" ]]; then
-                wget ${tools_git}/archive/refs/heads/main.zip
-                if [[ $? -eq 0 ]]; then
-                        unzip -q main.zip
-                        mv test_tools-wrappers-main ${TOOLS_BIN}
-                        rm main.zip
-                fi
-        fi
-}
-
-attempt_tools_curl()
-{
-        if [[ ! -d "$TOOLS_BIN" ]]; then
-                curl -L -O ${tools_git}/archive/refs/heads/main.zip
+                $method ${tools_git}/archive/refs/heads/main.zip
                 if [[ $? -eq 0 ]]; then
                         unzip -q main.zip
                         mv test_tools-wrappers-main ${TOOLS_BIN}
@@ -95,13 +84,13 @@ attempt_tools_git()
         if [[ ! -d "$TOOLS_BIN" ]]; then
                 git clone $tools_git "$TOOLS_BIN"
                 if [ $? -ne 0 ]; then
-                        exit_out "Error: pulling git $tools_git failed." 101
+                        exit "Error: pulling git $tools_git failed." 101
                 fi
         fi
 }
 
-attempt_tools_wget
-attempt_tools_curl
+attempt_tools_generic "wget"
+attempt_tools_generic "curl -L -O "
 attempt_tools_git
 
 usage()

--- a/hammerdb/hammerdb
+++ b/hammerdb/hammerdb
@@ -84,7 +84,8 @@ attempt_tools_git()
         if [[ ! -d "$TOOLS_BIN" ]]; then
                 git clone $tools_git "$TOOLS_BIN"
                 if [ $? -ne 0 ]; then
-                        exit "Error: pulling git $tools_git failed." 101
+			echo "Error: pulling git $tools_git failed."
+			exit 101
                 fi
         fi
 }


### PR DESCRIPTION
# Description
1) Removes duplicate code in the test_tools new code
2) Fixes exit_out not existing

# Before/After Comparison
Before: If we failed, we would get an error calling exit_out as it does not exist.
After: Error no longer occurs.

# Clerical Stuff
This closes #53 

Relates to JIRA: RPOPC-808

Testing done:
Verified each method works, and we get a proper message if we fail.

